### PR TITLE
Fix : house category, houseCase 필드 통일 #47

### DIFF
--- a/src/main/java/com/sparta/hanghaebnb/controller/HouseController.java
+++ b/src/main/java/com/sparta/hanghaebnb/controller/HouseController.java
@@ -68,9 +68,9 @@ public class HouseController {
     /**
      * 여행지 카테고리별 조회 Controller
      */
-    @GetMapping("/houses/category/{category}")
-    public List<HouseResponseDto> categoryHouse(@PathVariable String category){
-        return houseService.categoryHouses(category);
+    @GetMapping("/houses/houseCase/{houseCase}")
+    public List<HouseResponseDto> categoryHouse(@PathVariable String houseCase){
+        return houseService.categoryHouses(houseCase);
     }
 
     /**

--- a/src/main/java/com/sparta/hanghaebnb/dto/HouseRequestDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/HouseRequestDto.java
@@ -14,7 +14,6 @@ public class HouseRequestDto {
     private int price;
     private String explaination;
     private String location;
-    private String category;
     private int maxPeople;
     private String houseCase;
     private int bedRoom;

--- a/src/main/java/com/sparta/hanghaebnb/entity/House.java
+++ b/src/main/java/com/sparta/hanghaebnb/entity/House.java
@@ -31,8 +31,6 @@ public class House extends Timestamped{
     private String explaination;
 
     @Column(nullable = false)
-    private String category;
-    @Column(nullable = false)
     private String imgUrl;
 
     @Column(nullable = false)
@@ -61,12 +59,11 @@ public class House extends Timestamped{
     private List<WishListAndHouse> wishListAndHouseList = new ArrayList<>();
 
     @Builder
-    private House(String title, int price, String location, String explaination, String category, String imgUrl, int maxNumPeople, int bedNum, int bathNum, String houseCase, List<Facility> facilities, User user) {
+    private House(String title, int price, String location, String explaination, String imgUrl, int maxNumPeople, int bedNum, int bathNum, String houseCase, List<Facility> facilities, User user) {
         this.title = title;
         this.price = price;
         this.location = location;
         this.explaination = explaination;
-        this.category = category;
         this.imgUrl = imgUrl;
         this.maxNumPeople = maxNumPeople;
         this.bedNum = bedNum;
@@ -80,7 +77,6 @@ public class House extends Timestamped{
                 .title(houseRequestDto.getTitle())
                 .price(houseRequestDto.getPrice())
                 .location(houseRequestDto.getLocation())
-                .category(houseRequestDto.getCategory())
                 .explaination(houseRequestDto.getExplaination())
                 .imgUrl(imgUrl)
                 .maxNumPeople(houseRequestDto.getMaxPeople())
@@ -101,7 +97,6 @@ public class House extends Timestamped{
         this.price =houseRequestDto.getPrice();
         this.location = houseRequestDto.getLocation();
         this.explaination = houseRequestDto.getLocation();
-        this.category = houseRequestDto.getCategory();
         this.imgUrl = houseRequestDto.getFile().getName();
         this.maxNumPeople = houseRequestDto.getMaxPeople();
         this.bedNum = houseRequestDto.getBedRoom();

--- a/src/main/java/com/sparta/hanghaebnb/repository/HouseRepository.java
+++ b/src/main/java/com/sparta/hanghaebnb/repository/HouseRepository.java
@@ -10,7 +10,7 @@ public interface HouseRepository extends JpaRepository<House,Long> {
     //생성일 내림차순 전체 조회
     List<House> findAllByOrderByCreatedAtDesc();
     //카테고리에 따른 전체 여행지 검색
-    List<House> findAllByCategoryOrderByCreatedAtDesc(String category);
+    List<House> findAllByHouseCaseOrderByCreatedAtDesc(String houseCase);
     //제목에 키워드가 포함되어 있는 전체 여행지 검색
     List<House> findAllByTitleContainsOrderByCreatedAtDesc(String category);
 }

--- a/src/main/java/com/sparta/hanghaebnb/service/HouseService.java
+++ b/src/main/java/com/sparta/hanghaebnb/service/HouseService.java
@@ -94,8 +94,8 @@ public class HouseService {
     /**
      * 카테고리별 여행지 조회
      */
-    public List<HouseResponseDto> categoryHouses(String category) {
-        List<House> findHouses = houseRepository.findAllByCategoryOrderByCreatedAtDesc(category);
+    public List<HouseResponseDto> categoryHouses(String houseCase) {
+        List<House> findHouses = houseRepository.findAllByHouseCaseOrderByCreatedAtDesc(houseCase);
         return findHouses.stream().map(h -> HouseResponseDto.from(h,(int)(Math.random()*100),(int)(Math.random()*100))).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feat/house-field-> dev

### 변경 사항
- 기존 username만 따로 가져가던 형태에서 관계를 매핑하여 User 객체를 통째로 참조하도록 변경
- 게시글, 댓글 모두 수정/삭제 시 username과 일치하는게 아닌 userId와 일치하는 값을 조회

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
