### PR TITLE
Fix : 전체 조회 기능 관련 거리 데이터 추가 응답하기 #53

### DIFF
--- a/src/main/java/com/sparta/hanghaebnb/controller/HouseController.java
+++ b/src/main/java/com/sparta/hanghaebnb/controller/HouseController.java
@@ -1,14 +1,13 @@
 package com.sparta.hanghaebnb.controller;
 
-import com.sparta.hanghaebnb.dto.HouseRequestDto;
-import com.sparta.hanghaebnb.dto.HouseResponseDto;
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.request.HouseRequestDto;
+import com.sparta.hanghaebnb.dto.response.HouseResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import com.sparta.hanghaebnb.response.ApiDocumentResponse;
 import com.sparta.hanghaebnb.security.UserDetailsImpl;
 import com.sparta.hanghaebnb.service.HouseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/sparta/hanghaebnb/controller/ReviewController.java
+++ b/src/main/java/com/sparta/hanghaebnb/controller/ReviewController.java
@@ -1,12 +1,11 @@
 package com.sparta.hanghaebnb.controller;
 
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
-import com.sparta.hanghaebnb.dto.ReviewRequestDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.request.ReviewRequestDto;
 import com.sparta.hanghaebnb.response.ApiDocumentResponse;
 import com.sparta.hanghaebnb.security.UserDetailsImpl;
 import com.sparta.hanghaebnb.service.ReviewService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 @ApiDocumentResponse

--- a/src/main/java/com/sparta/hanghaebnb/controller/UserController.java
+++ b/src/main/java/com/sparta/hanghaebnb/controller/UserController.java
@@ -1,15 +1,14 @@
 package com.sparta.hanghaebnb.controller;
 
-import com.sparta.hanghaebnb.dto.LoginRequestDto;
-import com.sparta.hanghaebnb.dto.LoginResponseDto;
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
-import com.sparta.hanghaebnb.dto.SignupRequestDto;
+import com.sparta.hanghaebnb.dto.request.LoginRequestDto;
+import com.sparta.hanghaebnb.dto.response.LoginResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.request.SignupRequestDto;
 import com.sparta.hanghaebnb.response.ApiDocumentResponse;
 import com.sparta.hanghaebnb.security.UserDetailsImpl;
 import com.sparta.hanghaebnb.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/com/sparta/hanghaebnb/controller/WishListController.java
+++ b/src/main/java/com/sparta/hanghaebnb/controller/WishListController.java
@@ -1,6 +1,6 @@
 package com.sparta.hanghaebnb.controller;
 
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import com.sparta.hanghaebnb.response.ApiDocumentResponse;
 import com.sparta.hanghaebnb.security.UserDetailsImpl;
 import com.sparta.hanghaebnb.service.WishListService;

--- a/src/main/java/com/sparta/hanghaebnb/dto/request/HouseRequestDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/request/HouseRequestDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/sparta/hanghaebnb/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/request/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/hanghaebnb/dto/request/ReviewRequestDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/request/ReviewRequestDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/hanghaebnb/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/request/SignupRequestDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/hanghaebnb/dto/response/HouseResponseDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/response/HouseResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.response;
 
 import com.sparta.hanghaebnb.entity.House;
 import lombok.Builder;
@@ -9,28 +9,22 @@ import java.text.DecimalFormat;
 @Getter
 public class HouseResponseDto {
 
-    // 하우스 ID
     private Long id;
-    // 호스트명
     private String userNickname;
-    // 글 제목
     private String title;
-    // 하우스 위치
+    private String distance;
     private String location;
-    // 숙박료
     private String price;
-    // 하우스이미지
     private String imageUrl;
-    //좋아요 수
     private int likesNum;
-    //리뷰 수
     private int reviewNum;
 
     @Builder
-    public HouseResponseDto(Long id, String userNickname, String title, String location, String price, String imageUrl, int likesNum, int reviewNum) {
+    private HouseResponseDto(Long id, String userNickname, String title, String distance, String location, String price, String imageUrl, int likesNum, int reviewNum) {
         this.id = id;
         this.userNickname = userNickname;
         this.title = title;
+        this.distance = distance;
         this.location = location;
         this.price = price;
         this.imageUrl = imageUrl;
@@ -38,14 +32,18 @@ public class HouseResponseDto {
         this.reviewNum = reviewNum;
     }
 
-    public static HouseResponseDto from(House house, int likesNum , int reviewNum){
-        DecimalFormat priceFormat = new DecimalFormat("###,###");
+
+
+
+    public static HouseResponseDto of(House house,int likesNum , int reviewNum){
+        DecimalFormat format = new DecimalFormat("###,###");
         return HouseResponseDto.builder()
                 .id(house.getId())
                 .userNickname(house.getUser().getUsername())
                 .title(house.getTitle())
                 .location(house.getLocation())
-                .price(priceFormat.format(house.getPrice()))
+                .price(format.format(house.getPrice()))
+                .distance( format.format( (int) ( 1000 + Math.random() * 9000 ) ) )
                 .imageUrl(house.getImgUrl())
                 .likesNum(likesNum)
                 .reviewNum(reviewNum)

--- a/src/main/java/com/sparta/hanghaebnb/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/response/LoginResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/hanghaebnb/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/response/MessageResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.hanghaebnb.dto;
+package com.sparta.hanghaebnb.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/hanghaebnb/entity/House.java
+++ b/src/main/java/com/sparta/hanghaebnb/entity/House.java
@@ -1,6 +1,6 @@
 package com.sparta.hanghaebnb.entity;
 
-import com.sparta.hanghaebnb.dto.HouseRequestDto;
+import com.sparta.hanghaebnb.dto.request.HouseRequestDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/hanghaebnb/entity/Review.java
+++ b/src/main/java/com/sparta/hanghaebnb/entity/Review.java
@@ -1,6 +1,6 @@
 package com.sparta.hanghaebnb.entity;
 
-import com.sparta.hanghaebnb.dto.ReviewRequestDto;
+import com.sparta.hanghaebnb.dto.request.ReviewRequestDto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/sparta/hanghaebnb/entity/User.java
+++ b/src/main/java/com/sparta/hanghaebnb/entity/User.java
@@ -1,6 +1,5 @@
 package com.sparta.hanghaebnb.entity;
 
-import com.sparta.hanghaebnb.dto.SignupRequestDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/hanghaebnb/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/hanghaebnb/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.sparta.hanghaebnb.exception;
 
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/sparta/hanghaebnb/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/sparta/hanghaebnb/jwt/JwtAuthFilter.java
@@ -1,8 +1,7 @@
 package com.sparta.hanghaebnb.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
-import com.sparta.hanghaebnb.exception.ErrorCode;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/sparta/hanghaebnb/response/ApiResponse.java
+++ b/src/main/java/com/sparta/hanghaebnb/response/ApiResponse.java
@@ -1,6 +1,6 @@
 package com.sparta.hanghaebnb.response;
 
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/sparta/hanghaebnb/service/HouseService.java
+++ b/src/main/java/com/sparta/hanghaebnb/service/HouseService.java
@@ -1,8 +1,8 @@
 package com.sparta.hanghaebnb.service;
 
-import com.sparta.hanghaebnb.dto.HouseRequestDto;
-import com.sparta.hanghaebnb.dto.HouseResponseDto;
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.request.HouseRequestDto;
+import com.sparta.hanghaebnb.dto.response.HouseResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import com.sparta.hanghaebnb.entity.Facility;
 import com.sparta.hanghaebnb.entity.House;
 import com.sparta.hanghaebnb.exception.CustomException;
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -52,7 +51,9 @@ public class HouseService {
     @Transactional(readOnly = true)
     public List<HouseResponseDto> findAllHouse() {
         List<House> houses = houseRepository.findAllByOrderByCreatedAtDesc();
-        return houses.stream().map(h -> HouseResponseDto.from(h,(int)(Math.random()*100),(int)(Math.random()*100))).collect(Collectors.toList());
+        return houses.stream()
+                .map(h -> HouseResponseDto.of(h,(int)(Math.random()*100),(int)(Math.random()*100)))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -63,7 +64,7 @@ public class HouseService {
         House findHouse = houseRepository.findById(houseId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_HOUSE)
         );
-        return HouseResponseDto.from(findHouse,10,10);
+        return HouseResponseDto.of(findHouse,10,10);
     }
 
     /**
@@ -98,7 +99,7 @@ public class HouseService {
      */
     public List<HouseResponseDto> categoryHouses(String houseCase) {
         List<House> findHouses = houseRepository.findAllByHouseCaseOrderByCreatedAtDesc(houseCase);
-        return findHouses.stream().map(h -> HouseResponseDto.from(h,(int)(Math.random()*100),(int)(Math.random()*100))).collect(Collectors.toList());
+        return findHouses.stream().map(h -> HouseResponseDto.of(h,(int)(Math.random()*100),(int)(Math.random()*100))).collect(Collectors.toList());
     }
 
     /**
@@ -106,6 +107,6 @@ public class HouseService {
      */
     public List<HouseResponseDto> keywordHouse(String keyword) {
         List<House> findHouses = houseRepository.findAllByTitleContainsOrderByCreatedAtDesc(keyword);
-        return findHouses.stream().map(h -> HouseResponseDto.from(h,(int)(Math.random()*100),(int)(Math.random()*100))).collect(Collectors.toList());
+        return findHouses.stream().map(h -> HouseResponseDto.of(h,(int)(Math.random()*100),(int)(Math.random()*100))).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/sparta/hanghaebnb/service/ReviewService.java
+++ b/src/main/java/com/sparta/hanghaebnb/service/ReviewService.java
@@ -1,7 +1,7 @@
 package com.sparta.hanghaebnb.service;
 
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
-import com.sparta.hanghaebnb.dto.ReviewRequestDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.request.ReviewRequestDto;
 import com.sparta.hanghaebnb.entity.House;
 import com.sparta.hanghaebnb.entity.Review;
 import com.sparta.hanghaebnb.entity.User;
@@ -11,10 +11,8 @@ import com.sparta.hanghaebnb.repository.HouseRepository;
 import com.sparta.hanghaebnb.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.Optional;
 
 @Service

--- a/src/main/java/com/sparta/hanghaebnb/service/UserService.java
+++ b/src/main/java/com/sparta/hanghaebnb/service/UserService.java
@@ -1,9 +1,9 @@
 package com.sparta.hanghaebnb.service;
 
-import com.sparta.hanghaebnb.dto.LoginRequestDto;
-import com.sparta.hanghaebnb.dto.LoginResponseDto;
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
-import com.sparta.hanghaebnb.dto.SignupRequestDto;
+import com.sparta.hanghaebnb.dto.request.LoginRequestDto;
+import com.sparta.hanghaebnb.dto.response.LoginResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.request.SignupRequestDto;
 import com.sparta.hanghaebnb.entity.RefreshToken;
 import com.sparta.hanghaebnb.entity.User;
 import com.sparta.hanghaebnb.exception.CustomException;

--- a/src/main/java/com/sparta/hanghaebnb/service/WishListService.java
+++ b/src/main/java/com/sparta/hanghaebnb/service/WishListService.java
@@ -1,6 +1,6 @@
 package com.sparta.hanghaebnb.service;
 
-import com.sparta.hanghaebnb.dto.MessageResponseDto;
+import com.sparta.hanghaebnb.dto.response.MessageResponseDto;
 import com.sparta.hanghaebnb.entity.House;
 import com.sparta.hanghaebnb.entity.User;
 import com.sparta.hanghaebnb.entity.WishList;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
fix/distance-> dev

### 변경 사항
- 전체 조회 / 유형별 조회 / 검색 조회에서 거리 값 1000~10000 사이 랜덤으로 응답객체에 넣어주기
- Dto 패키지 관련 request / response 패키지로 구분
- HouseResponseDto from -> of로 메서드 명 변경
- HouseResponseDto 주석 제거
- HouseResponseDto 생성자 public -> private으로 변경( 정적 팩토리 메서드 사용으로 인함 )

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
