### PR TITLE
Refactor : refresh 메서드 수정

### DIFF
--- a/src/main/java/com/sparta/hanghaebnb/controller/UserController.java
+++ b/src/main/java/com/sparta/hanghaebnb/controller/UserController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+
 @ApiDocumentResponse
 @RestController
 @RequiredArgsConstructor
@@ -33,12 +34,12 @@ public class UserController {
     }
 
     @PostMapping("/logout")
-    public MessageResponseDto logout(@AuthenticationPrincipal UserDetailsImpl userDetails,HttpServletRequest request) {
-        return userService.logout(userDetails.getUser(),request);
+    public MessageResponseDto logout(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletRequest request) {
+        return userService.logout(userDetails.getUser(), request);
     }
 
     @PostMapping("/refresh")
-    public MessageResponseDto refresh(HttpServletRequest request, HttpServletResponse response, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return userService.refresh(request, response, userDetails.getUser());
+    public MessageResponseDto refresh(HttpServletRequest request, HttpServletResponse response) {
+        return userService.refresh(request, response);
     }
 }

--- a/src/main/java/com/sparta/hanghaebnb/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/sparta/hanghaebnb/dto/request/SignupRequestDto.java
@@ -7,12 +7,13 @@ import javax.validation.constraints.Pattern;
 @Getter
 public class SignupRequestDto {
     private String username;
-    @Pattern(regexp ="^([a-zA-Z[0-9]]){8,15}$", message = "비밀번호는 8자 이상의 영대소문자, 숫자만 가능합니다.")
+    @Pattern(regexp = "^([a-zA-Z[0-9]]){8,15}$", message = "비밀번호는 8자 이상의 영대소문자, 숫자만 가능합니다.")
     private String password;
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$"
             , message = "이메일 형식에 맞지 않습니다.")
     private String email;
     private String birth;
+
     public void setPassword(String password) {
         this.password = password;
     }

--- a/src/main/java/com/sparta/hanghaebnb/entity/RefreshToken.java
+++ b/src/main/java/com/sparta/hanghaebnb/entity/RefreshToken.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.Optional;
 
 @Getter
 @Entity
@@ -20,7 +19,7 @@ public class RefreshToken {
     private String token;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "USERS_ID",nullable = false)
+    @JoinColumn(name = "USERS_ID", nullable = false)
     private User user;
 
     @Builder

--- a/src/main/java/com/sparta/hanghaebnb/service/UserService.java
+++ b/src/main/java/com/sparta/hanghaebnb/service/UserService.java
@@ -80,7 +80,7 @@ public class UserService {
         return apiResponse.success("로그아웃 성공");
     }
 
-    public MessageResponseDto refresh(HttpServletRequest request, HttpServletResponse response, User user) {
+    public MessageResponseDto refresh(HttpServletRequest request, HttpServletResponse response) {
         String requestRT = request.getHeader(JwtUtil.RT_HEADER);
         Optional<RefreshToken> found = refreshTokenRepository.findByToken(requestRT);
         if (found.isEmpty()) {


### PR DESCRIPTION
refresh 메서드를 호출할시 인증 절차 제외
이유 : refresh 메서드는 access 토큰이 만료되어도 실행 가능해야함

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
refactor/refresh-> dev

### 변경 사항
- refresh 메서드 호출시 access 토큰의 validation 체크를 할 필요가 없어서 인증 절차 제외
- refresh 토큰의 유무 확인

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
